### PR TITLE
Attempt to fix intermittent docker segfaults

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,7 +367,7 @@ CHECKSUMS
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 RUBY VERSION
-   ruby 3.4.9p82
+  ruby 3.4.9p82
 
 BUNDLED WITH
-   2.7.2
+  4.0.8


### PR DESCRIPTION
Am getting random segfaults when building the docker image on the server. Happens when building native extensions, but the offending gem is always different. Trying a bundle upgrade first, then will try turning off parallelization if that doesn't work.

